### PR TITLE
allow falling-sky to run behind a reverse proxy using Apache >= 2.4

### DIFF
--- a/mod_ip.c
+++ b/mod_ip.c
@@ -122,9 +122,9 @@ const char *padding_buffer = "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldH
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 2 || \
     (AP_SERVER_MAJORVERSION_NUMBER == 2 && AP_SERVER_MINORVERSION_NUMBER >= 4)
-#define CLIENT_IP(conn) ((conn)->client_ip)
+#define CLIENT_IP(request) ((request)->useragent_ip)
 #else
-#define CLIENT_IP(conn) ((conn)->remote_ip)
+#define CLIENT_IP(request) ((request)->connection->remote_ip)
 #endif
 
 typedef struct mod_ip_request_t
@@ -355,7 +355,7 @@ gen_output (request_rec * r, struct mod_ip_request_t *formdata)
 	char *padding = ",\"padding\":\"";
 	char *p = NULL;
 	int added = 0;
-	char *myip = CLIENT_IP(r->connection);
+	char *myip = CLIENT_IP(r);
 	char *mytype = "ipv4";
 	char *mysubtype = "";
 	char *VIA = "";


### PR DESCRIPTION
If one configures falling-sky to run behind e.g. nginx, then the
user's IP address will be falsely reported as 127.0.0.1 or ::1, even
if the X-Forwarded-For and X-Real-IP headers are set correctly.

This patch fixes the problem iff compiled against Apache >= 2.4.
